### PR TITLE
j274: remove broken '"' on the convolver's channel property

### DIFF
--- a/firs/j274/graph.json
+++ b/firs/j274/graph.json
@@ -23,7 +23,7 @@
                         "/usr/share/asahi-audio/j274/96.wav",
                         "/usr/share/asahi-audio/j274/192.wav"
                     ],
-                    "channel": "0"
+                    "channel": 0
                 }
             }
         ],


### PR DESCRIPTION
The channel property expects a number. Fixes a easy to miss -EINVAL supposedly from strtol() or similar.