### PR TITLE
README: Speakers require out-of-tree patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,14 @@ a little bit of effort.
 
 ### Dependencies
 * speakersafetyd
-* linux-asahi 6.6-11 or above
+* linux-asahi 6.6-11 or above (see notes)
 * PipeWire 0.3.85 or above
 * WirePlumber 0.4.16 or above
 * Bankstown 1.0 or above
-* LSP Plugins (only the LV2 set of plugins are used)
+* LSP Plugins 1.0.20 or above (only the LV2 set of plugins are used)
+
+**Notes**: Due to a critical bug in lsp-plugins speaker are enabled via
+out-of-tree patches to ensure known fixed LSP plugins are present.
 
 ### Why this is necessary
 Microspeakers are terrible. They are too small to reproduce any substantial bass at all,


### PR DESCRIPTION
Fixed LSP plugins were released yesterday. Add the fixed version as dependency and not the out-of-tree patches for speakers.