### PR TITLE
j316: Make the minimum volume quieter

### DIFF
--- a/firs/j316/graph.json
+++ b/firs/j316/graph.json
@@ -191,13 +191,13 @@
         "capture.volumes": [
             {
                 "control": "ell:volume",
-                "min": -42.5,
+                "min": -65.0,
                 "max": 0.0,
                 "scale": "cubic"
             },
             {
                 "control": "elr:volume",
-                "min": -42.5,
+                "min": -65.0,
                 "max": 0.0,
                 "scale": "cubic"
             }


### PR DESCRIPTION
Fixes #19 

Disclaimer: I've only tried on my own setup where increasing or decreasing volume on the keyboard adds/removes `1%` volume via `wpctl set-volume @DEFAULT_AUDIO_SINK@ 1%+` and `wpctl set-volume @DEFAULT_AUDIO_SINK@ 1%-`. I'm not sure what the user experience is with GNOME or KDE where the steps might be bigger than 1% when using the dedicated keys on the keyboard (e.g. on macOS each key press adds ~6%), hopefully each key press doesn't add too much volume at once on those DE.