### PR TITLE
Fix filter path for J416

### DIFF
--- a/conf/wireplumber.conf
+++ b/conf/wireplumber.conf
@@ -138,7 +138,7 @@ node.software-dsp.rules = [
         ]
         actions = {
             create-filter = {
-                filter-path = "/usr/share/asahi-audio/j416/graph-j416.json"
+                filter-path = "/usr/share/asahi-audio/j316/graph-j416.json"
                 hide-parent = true
             }
         }


### PR DESCRIPTION
The filter path alias is installed under the `j316` directory.