### PR TITLE
conf: wireplumber: Fix & force speakers node name

### DIFF
--- a/conf/wireplumber.conf
+++ b/conf/wireplumber.conf
@@ -21,6 +21,9 @@ monitor.alsa.rules = [
         actions = {
             update-props = {
                 audio.allowed-rates = [48000, 44100]
+                node.name = "alsa_output.platform-sound.RawSpeakers"
+                node.description = "Raw Speaker Device (do not use)"
+                node.nick = "RawSpeakers"
             }
         }
     }

--- a/firs/j274/graph.json
+++ b/firs/j274/graph.json
@@ -154,7 +154,8 @@
     },
     "playback.props": {
         "node.name": "effect_output.j274-convolver",
-        "target.object": "alsa_output.platform-sound.HiFi__hw_AppleJ274_1__sink",
+        "target.object": "alsa_output.platform-sound.RawSpeakers",
+        "node.dont-fallback": "true",
         "node.passive": "true",
         "audio.channels": "2",
         "audio.allowed-rates": [48000, 44100],

--- a/firs/j293/graph.json
+++ b/firs/j293/graph.json
@@ -237,7 +237,8 @@
     },
     "playback.props": {
         "node.name": "effect_output.j293-convolver",
-        "target.object": "alsa_output.platform-sound.HiFi__hw_AppleJ293_1__sink",
+        "target.object": "alsa_output.platform-sound.RawSpeakers",
+        "node.dont-fallback": "true",
         "node.passive": "true",
         "audio.channels": "4",
         "audio.allowed-rates": [48000, 44100],

--- a/firs/j313/graph.json
+++ b/firs/j313/graph.json
@@ -157,7 +157,8 @@
     },
     "playback.props": {
         "node.name": "effect_output.j313-convolver",
-        "target.object": "alsa_output.platform-sound.HiFi__hw_AppleJ313_1__sink",
+        "target.object": "alsa_output.platform-sound.RawSpeakers",
+        "node.dont-fallback": "true",
         "node.passive": "true",
         "audio.channels": "2",
         "audio.allowed-rates": [48000, 44100],

--- a/firs/j314/graph.json
+++ b/firs/j314/graph.json
@@ -218,7 +218,8 @@
     },
     "playback.props": {
         "node.name": "effect_output.j314-convolver",
-        "target.object": "alsa_output.platform-sound.HiFi__hw_AppleJ314_1__sink",
+        "target.object": "alsa_output.platform-sound.RawSpeakers",
+        "node.dont-fallback": "true",
         "node.passive": "true",
         "audio.channels": "6",
         "audio.allowed-rates": [48000, 44100],

--- a/firs/j316/graph.json
+++ b/firs/j316/graph.json
@@ -217,7 +217,8 @@
     },
     "playback.props": {
         "node.name": "effect_output.j316-convolver",
-        "target.object": "alsa_output.platform-sound.HiFi__hw_AppleJ316_1__sink",
+        "target.object": "alsa_output.platform-sound.RawSpeakers",
+        "node.dont-fallback": "true",
         "node.passive": "true",
         "audio.channels": "6",
         "audio.allowed-rates": [48000, 44100],

--- a/firs/j375/graph.json
+++ b/firs/j375/graph.json
@@ -123,7 +123,8 @@
     },
     "playback.props": {
         "node.name": "effect_output.j375-convolver",
-        "target.object": "alsa_output.platform-sound.HiFi__hw_AppleJ375_1__sink",
+        "target.object": "alsa_output.platform-sound.RawSpeakers",
+        "node.dont-fallback": "true",
         "node.passive": "true",
         "audio.channels": "2",
         "audio.allowed-rates": [48000, 44100],

--- a/firs/j413/graph.json
+++ b/firs/j413/graph.json
@@ -191,7 +191,8 @@
     },
     "playback.props": {
         "node.name": "effect_output.j413-convolver",
-        "target.object": "alsa_output.platform-sound.HiFi__hw_AppleJ413_1__sink",
+        "target.object": "alsa_output.platform-sound.RawSpeakers",
+        "node.dont-fallback": "true",
         "node.passive": "true",
         "audio.channels": "4",
         "audio.allowed-rates": [48000, 44100],

--- a/firs/j415/graph.json
+++ b/firs/j415/graph.json
@@ -218,7 +218,8 @@
     },
     "playback.props": {
         "node.name": "effect_output.j415-convolver",
-        "target.object": "alsa_output.platform-sound.HiFi__hw_AppleJ415_1__sink",
+        "target.object": "alsa_output.platform-sound.RawSpeakers",
+        "node.dont-fallback": "true",
         "node.passive": "true",
         "audio.channels": "6",
         "audio.allowed-rates": [48000, 44100],


### PR DESCRIPTION
PipeWire commit 833c86d35 changed the profile name and therefore the node name for the internal speakers device. The only reason it was still working is because fallback device selection usually picked the internal speakers device.

To fix this and avoid the problem in the future, force the node name to a constant in the WP config and then target that in the DSP configs. Also set dont-fallback so that if this fails for some reason, the DSP doesn't try to bind to some other random device.

While we're here also make the nick and description more helpful (this mostly affects how the node shows up in Carla/JACK, since it's otherwise hidden... hopefully).