### PR TITLE
jXXX: Reduce equal-loudness FFT size from 4096 to 1024

### DIFF
--- a/firs/j274/graph.json
+++ b/firs/j274/graph.json
@@ -24,7 +24,7 @@
                 "control": {
                     "enabled": 1,
                     "input": 1.0,
-                    "fft": 4
+                    "fft": 2
                 }
             },
             {
@@ -34,7 +34,7 @@
                 "control": {
                     "enabled": 1,
                     "input": 1.0,
-                    "fft": 4
+                    "fft": 2
                 }
             },
             {

--- a/firs/j293/graph.json
+++ b/firs/j293/graph.json
@@ -24,7 +24,7 @@
                 "control": {
                     "enabled": 1,
                     "input": 1.0,
-                    "fft": 4
+                    "fft": 2
                 }
             },
             {
@@ -34,7 +34,7 @@
                 "control": {
                     "enabled": 1,
                     "input": 1.0,
-                    "fft": 4
+                    "fft": 2
                 }
             },
             {

--- a/firs/j313/graph.json
+++ b/firs/j313/graph.json
@@ -24,7 +24,7 @@
                 "control": {
                     "enabled": 1,
                     "input": 1.0,
-                    "fft": 4
+                    "fft": 2
                 }
             },
             {
@@ -34,7 +34,7 @@
                 "control": {
                     "enabled": 1,
                     "input": 1.0,
-                    "fft": 4
+                    "fft": 2
                 }
             },
             {

--- a/firs/j314/graph.json
+++ b/firs/j314/graph.json
@@ -25,7 +25,7 @@
                 "control": {
                     "enabled": 1,
                     "input": 1.0,
-                    "fft": 4
+                    "fft": 2
                 }
             },
             {
@@ -35,7 +35,7 @@
                 "control": {
                     "enabled": 1,
                     "input": 1.0,
-                    "fft": 4
+                    "fft": 2
                 }
             },
             {

--- a/firs/j316/graph.json
+++ b/firs/j316/graph.json
@@ -24,7 +24,7 @@
                 "control": {
                     "enabled": 1,
                     "input": 1.0,
-                    "fft": 4
+                    "fft": 2
                 }
             },
             {
@@ -34,7 +34,7 @@
                 "control": {
                     "enabled": 1,
                     "input": 1.0,
-                    "fft": 4
+                    "fft": 2
                 }
             },
             {

--- a/firs/j375/graph.json
+++ b/firs/j375/graph.json
@@ -24,7 +24,7 @@
                 "control": {
                     "enabled": 1,
                     "input": 1.0,
-                    "fft": 4
+                    "fft": 2
                 }
             },
             {
@@ -34,7 +34,7 @@
                 "control": {
                     "enabled": 1,
                     "input": 1.0,
-                    "fft": 4
+                    "fft": 2
                 }
             },
             {

--- a/firs/j413/graph.json
+++ b/firs/j413/graph.json
@@ -24,7 +24,7 @@
                 "control": {
                     "enabled": 1,
                     "input": 1.0,
-                    "fft": 4
+                    "fft": 2
                 }
             },
             {
@@ -34,7 +34,7 @@
                 "control": {
                     "enabled": 1,
                     "input": 1.0,
-                    "fft": 4
+                    "fft": 2
                 }
             },
             {

--- a/firs/j415/graph.json
+++ b/firs/j415/graph.json
@@ -25,7 +25,7 @@
                 "control": {
                     "enabled": 1,
                     "input": 1.0,
-                    "fft": 4
+                    "fft": 2
                 }
             },
             {
@@ -35,7 +35,7 @@
                 "control": {
                     "enabled": 1,
                     "input": 1.0,
-                    "fft": 4
+                    "fft": 2
                 }
             },
             {


### PR DESCRIPTION
This is actually the largest contributor to DSP latency. At the minimum, the speakers actually become usable for playing live music.

Should also reduce the clicking on start/stop due to the buffered samples.

I get the feeling this algorithm should be implementable with zero latency... it's just an EQ after all, and I think zero-latency FFT approaches exist too?