### PR TITLE
Change the names of the speakers playback nodes for avoid confusion

### DIFF
--- a/firs/j274/graph.json
+++ b/firs/j274/graph.json
@@ -152,6 +152,8 @@
         "device.icon-name": "audio-speakers"
     },
     "playback.props": {
+        "node.description": "Mac mini speaker (Playback)",
+        "media.name": "Mac mini Speaker (Playback)",
         "node.name": "effect_output.j274-convolver",
         "target.object": "alsa_output.platform-sound.RawSpeakers",
         "node.dont-fallback": "true",

--- a/firs/j293/graph.json
+++ b/firs/j293/graph.json
@@ -234,6 +234,8 @@
         "device.icon-name": "audio-speakers"
     },
     "playback.props": {
+        "node.description": "MacBook Pro J293 Speakers (Playback)",
+        "media.name": "MacBook Pro J293 Speakers (Playback)",
         "node.name": "effect_output.j293-convolver",
         "target.object": "alsa_output.platform-sound.RawSpeakers",
         "node.dont-fallback": "true",

--- a/firs/j313/graph.json
+++ b/firs/j313/graph.json
@@ -155,6 +155,8 @@
         "device.icon-name": "audio-speakers"
     },
     "playback.props": {
+        "node.description": "MacBook Air J313 Speakers (Playback)",
+        "media.name": "MacBook Air J313 Speakers (Playback)",
         "node.name": "effect_output.j313-convolver",
         "target.object": "alsa_output.platform-sound.RawSpeakers",
         "node.dont-fallback": "true",

--- a/firs/j314/graph.json
+++ b/firs/j314/graph.json
@@ -216,6 +216,8 @@
         "device.icon-name": "audio-speakers"
     },
     "playback.props": {
+        "node.description": "MacBook Pro J314 Speakers (Playback)",
+        "media.name": "MacBook Pro J314 Speakers (Playback)",
         "node.name": "effect_output.j314-convolver",
         "target.object": "alsa_output.platform-sound.RawSpeakers",
         "node.dont-fallback": "true",

--- a/firs/j316/graph.json
+++ b/firs/j316/graph.json
@@ -215,6 +215,8 @@
         "device.icon-name": "audio-speakers"
     },
     "playback.props": {
+        "node.description": "MacBook Pro J316 Speakers (Playback)",
+        "media.name": "MacBook Pro J316 Speakers (Playback)",
         "node.name": "effect_output.j316-convolver",
         "target.object": "alsa_output.platform-sound.RawSpeakers",
         "node.dont-fallback": "true",

--- a/firs/j375/graph.json
+++ b/firs/j375/graph.json
@@ -122,6 +122,8 @@
         "device.icon-name": "audio-speakers"
     },
     "playback.props": {
+        "node.description": "Mac Studio Speaker (Playback)",
+        "media.name": "Mac Studio Speaker (Playback)",
         "node.name": "effect_output.j375-convolver",
         "target.object": "alsa_output.platform-sound.RawSpeakers",
         "node.dont-fallback": "true",

--- a/firs/j413/graph.json
+++ b/firs/j413/graph.json
@@ -189,6 +189,8 @@
         "device.icon-name": "audio-speakers"
     },
     "playback.props": {
+        "node.description": "MacBook Air J413 Speakers (Playback)",
+        "media.name": "MacBook Air J413 Speakers (Playback)",
         "node.name": "effect_output.j413-convolver",
         "target.object": "alsa_output.platform-sound.RawSpeakers",
         "node.dont-fallback": "true",

--- a/firs/j415/graph.json
+++ b/firs/j415/graph.json
@@ -216,6 +216,8 @@
         "device.icon-name": "audio-speakers"
     },
     "playback.props": {
+        "node.description": "MacBook Air J415 Speakers (Playback)",
+        "media.name": "MacBook Air J415 Speakers (Playback)",
         "node.name": "effect_output.j415-convolver",
         "target.object": "alsa_output.platform-sound.RawSpeakers",
         "node.dont-fallback": "true",


### PR DESCRIPTION
There are shouldn't be nodes with the same name.
Fixes https://github.com/AsahiLinux/asahi-audio/issues/57

Now it looks more user-friendly:
![image](https://github.com/user-attachments/assets/521fccce-aeb4-4527-9281-b3a31aedcf55)
