### PR TITLE
mic: use AUX positions so all 3 input ports instantiate

### DIFF
--- a/firs/j293/mic.json
+++ b/firs/j293/mic.json
@@ -80,7 +80,7 @@
     "capture.props": {
         "node.name": "audio_effect.j293-mic",
         "audio.channels": "3",
-        "audio.position": ["FL", "FR", "LFE"],
+        "audio.position": ["AUX0", "AUX1", "AUX2"],
         "audio.allowed-rates": [48000],
         "node.virtual": "false",
         "state.default-volume": 1.00,

--- a/firs/j313/mic.json
+++ b/firs/j313/mic.json
@@ -80,7 +80,7 @@
     "capture.props": {
         "node.name": "audio_effect.j313-mic",
         "audio.channels": "3",
-        "audio.position": ["FL", "FR", "LFE"],
+        "audio.position": ["AUX0", "AUX1", "AUX2"],
         "audio.allowed-rates": [48000],
         "node.virtual": "false",
         "state.default-volume": 1.00,

--- a/firs/j314/mic.json
+++ b/firs/j314/mic.json
@@ -80,7 +80,7 @@
     "capture.props": {
         "node.name": "audio_effect.j314-mic",
         "audio.channels": "3",
-        "audio.position": ["FL", "FR", "LFE"],
+        "audio.position": ["AUX0", "AUX1", "AUX2"],
         "audio.allowed-rates": [48000],
         "node.virtual": "false",
         "state.default-volume": 1.00,

--- a/firs/j316/mic.json
+++ b/firs/j316/mic.json
@@ -80,7 +80,7 @@
     "capture.props": {
         "node.name": "audio_effect.j316-mic",
         "audio.channels": "3",
-        "audio.position": ["FL", "FR", "LFE"],
+        "audio.position": ["AUX0", "AUX1", "AUX2"],
         "audio.allowed-rates": [48000],
         "node.virtual": "false",
         "state.default-volume": 1.00,

--- a/firs/j413/mic.json
+++ b/firs/j413/mic.json
@@ -80,7 +80,7 @@
     "capture.props": {
         "node.name": "audio_effect.j413-mic",
         "audio.channels": "3",
-        "audio.position": ["FL", "FR", "LFE"],
+        "audio.position": ["AUX0", "AUX1", "AUX2"],
         "audio.allowed-rates": [48000],
         "node.virtual": "false",
         "state.default-volume": 1.00,

--- a/firs/j415/mic.json
+++ b/firs/j415/mic.json
@@ -80,7 +80,7 @@
     "capture.props": {
         "node.name": "audio_effect.j415-mic",
         "audio.channels": "3",
-        "audio.position": ["FL", "FR", "LFE"],
+        "audio.position": ["AUX0", "AUX1", "AUX2"],
         "audio.allowed-rates": [48000],
         "node.virtual": "false",
         "state.default-volume": 1.00,


### PR DESCRIPTION
PipeWire's module-filter-chain drops the LFE input port when a capture node declares audio.position = ["FL", "FR", "LFE"]. Only input_FL and input_FR are created, so WirePlumber auto-links RawMics:capture_AUX0/1 but leaves capture_AUX2 unconnected. The triforce beamformer then runs with one of three inputs unbound and outputs near-silence on every 3-mic MacBook (M1/M2/M3 Air + Pro).

Labelling the capture ports AUX0/AUX1/AUX2 bypasses speaker-position channel-map negotiation and matches the RawMics ALSA source's own port names verbatim, so all three input ports appear and link 1:1.

Verified on J416 (MacBook Pro 16" M2 Max), PipeWire 1.6.4 and 1.6.6, WirePlumber 0.5.14, Fedora Asahi Remix 44, kernel 6.19.14-asahi:

  - Before: parecord effect_output.j416-mic -> peak 0.42 %FS, RMS 10 (pw-cli: 2 input ports created, AUX2 unlinked)
  - After:  parecord effect_output.j416-mic -> peak 2.89 %FS, RMS 199 (pw-cli: 3 input ports, all RawMics channels linked; quiet room ambient; speech audible on paplay)

Isolated test: the audio.channels string "3" form parses fine; only the position rename is load-bearing, so the minimal patch is a single line change per affected config file.