### PR TITLE
fix(j314): correct mic output routing and volume (#1)

### DIFF
--- a/firs/j314/mic.json
+++ b/firs/j314/mic.json
@@ -107,6 +107,6 @@
         "node.virtual": "false",
         "state.default-volume": 0.343,
         "audio.allowed-rates": [8000, 11025, 16000, 22050, 44100, 48000],
-        "audio.position": ["AUX0"]
+        "audio.position": ["MONO"]
     }
 }


### PR DESCRIPTION
* fix(j314): use MONO channel position for mic playback output

AUX0 causes PulseAudio to route mono audio only to the front-left channel. MONO duplicates the signal to both speakers.

* fix(j314): set mic default output volume to 70%

The original commit (de0b801) set state.default-volume to 0.343 while the commit message stated 70%. The value 0.343 is 34.3%, not 70%. Corrected to 0.70 (70%).